### PR TITLE
Whitelist the seen_cookie_message

### DIFF
--- a/cypress/integration/smoke-test.js
+++ b/cypress/integration/smoke-test.js
@@ -1,14 +1,15 @@
 beforeEach(function () {
     cy.fixture('postcodes.json').as('postcodes')
     Cypress.Cookies.defaults({
-        whitelist: '_get_help_to_retrain_session'
+        whitelist: ['_get_help_to_retrain_session', 'seen_cookie_message']
     });
 })
 
 describe('Get help to retrain smoke test', function() {
-    it('should open the service landing page, submit a valid post code and display results', function() {
+    it('should open the service landing page, submits PID information and display results', function() {
         cy.visit('/');
         cy.contains('Accept cookies').click();
+
         cy.get('[data-cy=start-now-btn]').click();
         cy.get('[data-cy=pid-first-name-field]').type("test");
         cy.get('[data-cy=pid-surname-field]').type("test");


### PR DESCRIPTION
Get help to retrain smoke test step
did not have the seen_cookie_message whitelisted
therefore the banner was not going away and
was preventing further interaction with the page.

Also update the test description.