### PR TITLE
Add extra training page to accessibility tests to fix flow

### DIFF
--- a/cypress/integration/happy-path-with-accessibility.js
+++ b/cypress/integration/happy-path-with-accessibility.js
@@ -114,6 +114,11 @@ describe('Get help to retrain smoke test', function() {
     checkAccessibility();
   });
 
+  it('should allow me to choose computer skills training options', function() {
+    cy.contains('Continue').click();
+    checkAccessibility();
+  });
+
   it('should allow me to choose job hunting advice and navigate to action plan', function() {
     cy.contains('Continue').click();
     checkAccessibility();


### PR DESCRIPTION
Tests are currently failing as we don't have a step for the new training computer skills page. Add the step to continue the journey to the action page