### PR TITLE
Update target job to select job test step

### DIFF
--- a/cypress/integration/happy-path-with-accessibility.js
+++ b/cypress/integration/happy-path-with-accessibility.js
@@ -103,8 +103,8 @@ describe('Get help to retrain smoke test', function() {
     checkAccessibility();
   });
 
-  it('should allow me to target a job', function() {
-    cy.contains('Target this type of work').click();
+  it('should allow me to select a job', function() {
+    cy.get('input[value="Select this type of work"]').click();
     checkAccessibility();
   });
 


### PR DESCRIPTION
Smoke tests were broken because of a recent copy change:

`Update target job to select job test step`